### PR TITLE
Add `as_ptr` impl (requires Rust 1.45+)

### DIFF
--- a/src/shared_pointer/kind/arc/mod.rs
+++ b/src/shared_pointer/kind/arc/mod.rs
@@ -73,6 +73,11 @@ impl SharedPointerKind for ArcK {
     }
 
     #[inline(always)]
+    unsafe fn as_ptr<T>(&self) -> *const T {
+        Arc::as_ptr(self.as_inner_ref())
+    }
+
+    #[inline(always)]
     unsafe fn deref<T>(&self) -> &T {
         self.as_inner_ref::<T>().as_ref()
     }

--- a/src/shared_pointer/kind/arc/test.rs
+++ b/src/shared_pointer/kind/arc/test.rs
@@ -25,6 +25,19 @@ fn test_from_box_t() {
 }
 
 #[test]
+fn test_as_ptr() {
+    let x = PointerKind::new::<&'static str>("hello");
+
+    unsafe {
+        let y = PointerKind::clone::<&'static str>(&x);
+        let x_ptr: *const &'static str = PointerKind::as_ptr(&x);
+
+        assert_eq!(x_ptr, PointerKind::as_ptr(&y));
+        assert_eq!(*x_ptr, "hello");
+    }
+}
+
+#[test]
 fn test_deref() {
     let mut ptr_42 = PointerKind::new::<i32>(42);
     let mut ptr_box_dyn_hello = PointerKind::new::<Box<dyn ToString>>(Box::new("hello"));

--- a/src/shared_pointer/kind/mod.rs
+++ b/src/shared_pointer/kind/mod.rs
@@ -23,6 +23,7 @@ use core::fmt::Debug;
 pub trait SharedPointerKind: Sized + Debug {
     fn new<T>(v: T) -> Self;
     fn from_box<T>(v: Box<T>) -> Self;
+    unsafe fn as_ptr<T>(&self) -> *const T;
     unsafe fn deref<T>(&self) -> &T;
     unsafe fn try_unwrap<T>(self) -> Result<T, Self>;
     unsafe fn get_mut<T>(&mut self) -> Option<&mut T>;

--- a/src/shared_pointer/kind/rc/mod.rs
+++ b/src/shared_pointer/kind/rc/mod.rs
@@ -73,6 +73,11 @@ impl SharedPointerKind for RcK {
     }
 
     #[inline(always)]
+    unsafe fn as_ptr<T>(&self) -> *const T {
+        Rc::as_ptr(self.as_inner_ref())
+    }
+
+    #[inline(always)]
     unsafe fn deref<T>(&self) -> &T {
         self.as_inner_ref::<T>().as_ref()
     }

--- a/src/shared_pointer/kind/rc/test.rs
+++ b/src/shared_pointer/kind/rc/test.rs
@@ -21,6 +21,19 @@ fn test_from_box_t() {
 }
 
 #[test]
+fn test_as_ptr() {
+    let x = PointerKind::new::<&'static str>("hello");
+
+    unsafe {
+        let y = PointerKind::clone::<&'static str>(&x);
+        let x_ptr: *const &'static str = PointerKind::as_ptr(&x);
+
+        assert_eq!(x_ptr, PointerKind::as_ptr(&y));
+        assert_eq!(*x_ptr, "hello");
+    }
+}
+
+#[test]
 fn test_deref() {
     let mut ptr_42 = PointerKind::new::<i32>(42);
     let mut ptr_box_dyn_hello = PointerKind::new::<Box<dyn ToString>>(Box::new("hello"));

--- a/src/shared_pointer/mod.rs
+++ b/src/shared_pointer/mod.rs
@@ -98,6 +98,11 @@ where
     }
 
     #[inline(always)]
+    pub fn as_ptr(this: &Self) -> *const T {
+        unsafe { this.ptr.as_ptr::<T>() }
+    }
+
+    #[inline(always)]
     pub fn try_unwrap(mut this: SharedPointer<T, P>) -> Result<T, SharedPointer<T, P>> {
         let ptr: P = unsafe { ManuallyDrop::take(&mut this.ptr) };
 

--- a/src/shared_pointer/test.rs
+++ b/src/shared_pointer/test.rs
@@ -16,6 +16,16 @@ use std::string::ToString;
 assert_impl_all!(SharedPointer<i32, ArcK>: Send, Sync);
 
 #[test]
+fn test_as_ptr() {
+    let x = SharedPointer::<&'static str, RcK>::new("hello");
+    let y = SharedPointer::clone(&x);
+    let x_ptr: *const &'static str = SharedPointer::as_ptr(&x);
+
+    assert_eq!(x_ptr, SharedPointer::as_ptr(&y));
+    assert_eq!(unsafe { *x_ptr }, "hello");
+}
+
+#[test]
 fn test_deref() {
     let ptr_42: SharedPointer<i32, RcK> = SharedPointer::new(42);
     let ptr_box_dyn_hello: SharedPointer<Box<dyn ToString>, RcK> =


### PR DESCRIPTION
Hello!

I was able to add this library to [my project](https://github.com/attackgoat/screen-13/pull/3) and enable awesome Rc/Arc configurability. This crate is a gem. 💯

During implementation I had to add support for the Rc/Arc `as_ptr` functions added in Rust 1.45, so I'm hoping this contribution works for you too.

Other recent Rc/Arc APIs I noticed are absent are `pin` and `downgrade`.