### PR TITLE
Require `T: Send + Sync` for `SharedPointer<T, _>: {Send,Sync}`

### DIFF
--- a/src/shared_pointer/mod.rs
+++ b/src/shared_pointer/mod.rs
@@ -81,7 +81,11 @@ where
 {
     ptr: ManuallyDrop<P>,
     _phantom_t: PhantomData<T>,
+    _phantom_no_send_sync: PhantomData<*mut ()>,
 }
+
+unsafe impl<T: Sync + Send, P: Send> Send for SharedPointer<T, P> where P: SharedPointerKind {}
+unsafe impl<T: Sync + Send, P: Sync> Sync for SharedPointer<T, P> where P: SharedPointerKind {}
 
 impl<T, P> SharedPointer<T, P>
 where
@@ -89,7 +93,11 @@ where
 {
     #[inline(always)]
     fn new_from_inner(ptr: P) -> SharedPointer<T, P> {
-        SharedPointer { ptr: ManuallyDrop::new(ptr), _phantom_t: PhantomData }
+        SharedPointer {
+            ptr: ManuallyDrop::new(ptr),
+            _phantom_t: PhantomData,
+            _phantom_no_send_sync: PhantomData,
+        }
     }
 
     #[inline(always)]

--- a/tests/compile-fail/shared_pointer_arc_of_non_send_is_not_send_nor_sync.rs
+++ b/tests/compile-fail/shared_pointer_arc_of_non_send_is_not_send_nor_sync.rs
@@ -1,0 +1,14 @@
+extern crate archery;
+extern crate static_assertions;
+
+use archery::*;
+use static_assertions::assert_impl_all;
+use std::sync::MutexGuard;
+
+assert_impl_all!(SharedPointer<MutexGuard<'static, ()>, ArcK>: Send);
+//~^ ERROR cannot be sent between threads safely
+
+assert_impl_all!(SharedPointer<MutexGuard<'static, ()>, ArcK>: Sync);
+//~^ ERROR cannot be sent between threads safely
+
+fn main() {}

--- a/tests/compile-fail/shared_pointer_arc_of_non_send_nor_sync_is_not_send_nor_sync.rs
+++ b/tests/compile-fail/shared_pointer_arc_of_non_send_nor_sync_is_not_send_nor_sync.rs
@@ -7,8 +7,10 @@ use archery::*;
 
 assert_impl_all!(SharedPointer<Rc<i32>, ArcK>: Send);
 //~^ ERROR cannot be sent between threads safely
+//~^^ ERROR cannot be shared between threads safely
 
 assert_impl_all!(SharedPointer<Rc<i32>, ArcK>: Sync);
-//~^ ERROR cannot be shared between threads safely
+//~^ ERROR cannot be sent between threads safely
+//~^^ ERROR cannot be shared between threads safely
 
 fn main() {}

--- a/tests/compile-fail/shared_pointer_arc_of_non_sync_is_not_send_nor_sync.rs
+++ b/tests/compile-fail/shared_pointer_arc_of_non_sync_is_not_send_nor_sync.rs
@@ -1,0 +1,14 @@
+extern crate archery;
+extern crate static_assertions;
+
+use archery::*;
+use static_assertions::assert_impl_all;
+use std::cell::Cell;
+
+assert_impl_all!(SharedPointer<Cell<()>, ArcK>: Send);
+//~^ ERROR cannot be shared between threads safely
+
+assert_impl_all!(SharedPointer<Cell<()>, ArcK>: Sync);
+//~^ ERROR cannot be shared between threads safely
+
+fn main() {}


### PR DESCRIPTION
Fixes #18