### PR TITLE
Add `SharedPointer::pin`, implement `Unpin` unconditionally

### DIFF
--- a/src/shared_pointer/kind/arc/mod.rs
+++ b/src/shared_pointer/kind/arc/mod.rs
@@ -63,7 +63,7 @@ impl ArcK {
     }
 }
 
-impl SharedPointerKind for ArcK {
+unsafe impl SharedPointerKind for ArcK {
     #[inline(always)]
     fn new<T>(v: T) -> ArcK {
         ArcK::new_from_inner(Arc::new(v))

--- a/src/shared_pointer/kind/rc/mod.rs
+++ b/src/shared_pointer/kind/rc/mod.rs
@@ -63,7 +63,7 @@ impl RcK {
     }
 }
 
-impl SharedPointerKind for RcK {
+unsafe impl SharedPointerKind for RcK {
     #[inline(always)]
     fn new<T>(v: T) -> RcK {
         RcK::new_from_inner(Rc::new(v))

--- a/src/shared_pointer/mod.rs
+++ b/src/shared_pointer/mod.rs
@@ -83,6 +83,8 @@ where
     _phantom_t: PhantomData<T>,
 }
 
+impl<T, P> Unpin for SharedPointer<T, P> where P: SharedPointerKind {}
+
 impl<T, P> SharedPointer<T, P>
 where
     P: SharedPointerKind,

--- a/src/shared_pointer/mod.rs
+++ b/src/shared_pointer/mod.rs
@@ -17,6 +17,7 @@ use core::marker::PhantomData;
 use core::mem;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
+use core::pin::Pin;
 use core::ptr;
 
 /// Pointer to shared data with reference-counting.
@@ -97,6 +98,11 @@ where
     #[inline(always)]
     pub fn new(v: T) -> SharedPointer<T, P> {
         SharedPointer::new_from_inner(P::new::<T>(v))
+    }
+
+    #[inline(always)]
+    pub fn pin(v: T) -> Pin<SharedPointer<T, P>> {
+        unsafe { Pin::new_unchecked(Self::new(v)) }
     }
 
     #[inline(always)]


### PR DESCRIPTION
This PR introduces `SharedPointer::pin`, a counterpart of the [`std::{rc::Rc,sync::Arc}::pin`](https://doc.rust-lang.org/1.68.0/std/sync/struct.Arc.html#method.pin) associated functions.

Pinned immutable references are useful for self-referencing types and intrusive data structures, e.g., `Future`s created by async closures and [`interlock::hl::slice::SliceIntervalRwLock`](https://docs.rs/interlock/0.0.3/interlock/hl/slice/struct.SliceIntervalRwLock.html).

This PR also implements `SharedPointer: Unpin` to indicate that `SharedPointer` itself can be unpinned freely.